### PR TITLE
Add reference to Scene's build index

### DIFF
--- a/unity-scene-reference/Assets/source/SceneReference.cs
+++ b/unity-scene-reference/Assets/source/SceneReference.cs
@@ -6,6 +6,7 @@ using Object = UnityEngine.Object;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEditor.VersionControl;
+using UnityEngine.SceneManagement;
 #endif
 
 // Author: JohannesMP (2018-08-12)
@@ -50,6 +51,8 @@ public class SceneReference : ISerializationCallbackReceiver
     // This should only ever be set during serialization/deserialization!
     [SerializeField]
     private string scenePath = string.Empty;
+    [SerializeField]
+    private int buildIndex = -1;
 
     // Use this when you want to actually have the scene path
     public string ScenePath
@@ -70,6 +73,7 @@ public class SceneReference : ISerializationCallbackReceiver
             scenePath = value;
 #if UNITY_EDITOR
             sceneAsset = GetSceneAssetFromPath();
+            buildIndex = SceneUtility.GetBuildIndexByScenePath(scenePath);
 #endif
         }
     }
@@ -78,7 +82,11 @@ public class SceneReference : ISerializationCallbackReceiver
     {
         get
         {
-            return UnityEngine.SceneManagement.SceneUtility.GetBuildIndexByScenePath(scenePath);
+#if UNITY_EDITOR
+            return SceneUtility.GetBuildIndexByScenePath(ScenePath);
+#else
+            return buildIndex;
+#endif
         }
     }
 
@@ -103,8 +111,6 @@ public class SceneReference : ISerializationCallbackReceiver
         EditorApplication.update += HandleAfterDeserialize;
 #endif
     }
-
-
 
 #if UNITY_EDITOR
     private SceneAsset GetSceneAssetFromPath()
@@ -132,6 +138,8 @@ public class SceneReference : ISerializationCallbackReceiver
         {
             scenePath = GetScenePathFromAsset();
         }
+
+        buildIndex = SceneUtility.GetBuildIndexByScenePath(scenePath);
     }
 
     private void HandleAfterDeserialize()
@@ -145,7 +153,11 @@ public class SceneReference : ISerializationCallbackReceiver
 
         sceneAsset = GetSceneAssetFromPath();
         // No asset found, path was invalid. Make sure we don't carry over the old invalid path
-        if (!sceneAsset) scenePath = string.Empty;
+        if (!sceneAsset)
+        {
+            scenePath = string.Empty;
+            buildIndex = -1;
+        }
 
         if (!Application.isPlaying) EditorSceneManager.MarkAllScenesDirty();
     }

--- a/unity-scene-reference/Assets/source/SceneReference.cs
+++ b/unity-scene-reference/Assets/source/SceneReference.cs
@@ -74,6 +74,14 @@ public class SceneReference : ISerializationCallbackReceiver
         }
     }
 
+    public int BuildIndex
+    {
+        get
+        {
+            return UnityEngine.SceneManagement.SceneUtility.GetBuildIndexByScenePath(scenePath);
+        }
+    }
+
     public static implicit operator string(SceneReference sceneReference)
     {
         return sceneReference.ScenePath;


### PR DESCRIPTION
`SceneManagement.SceneUtility.GetBuildIndexByScenePath` is an easy way to get the scene's build index from the path. Since we're already working with the path, it's a no-brainer.

I've tested loading scenes via `sceneReference.BuildIndex` and it works as well. If the `scenePath` is null or invalid, it will return `-1`.

Closes #10 